### PR TITLE
Changed schema_block from an id to a class

### DIFF
--- a/lib/css/schema-style.css
+++ b/lib/css/schema-style.css
@@ -1,4 +1,4 @@
-#schema_block {
+.schema_block {
 	clear:both;
 	margin:0 auto 10px auto;
 	background: #EEEEEE;
@@ -7,37 +7,37 @@
     overflow: hidden;
 }
 
-#schema_block div {
+.schema_block div {
 	margin-bottom:10px;
 }
 
-#schema_block p {
+.schema_block p {
 	margin: 0 0 7px;
 	padding: 0;
 }
 
-#schema_block p.stacked {
+.schema_block p.stacked {
 	margin: 0 0 2px 0;
 	padding: 0;
 }
 
-#schema_block .schema_name {
+.schema_block .schema_name {
 	font-weight:700;
 	margin-bottom:10px;
 }
 
-#schema_block .schema_strong {
+.schema_block .schema_strong {
 	font-weight:700;
 }
 
-#schema_block .schema_description,
-#schema_block .schema_instructions {
+.schema_block .schema_description,
+.schema_block .schema_instructions {
 	margin-bottom:10px;
 }
 
 /* a few things for recipes */
 
-#schema_block .header_type {
+.schema_block .header_type {
 	font-size:110%;
 	font-weight:700;
 }
@@ -47,12 +47,12 @@
 	font-weight:400;
 }
 
-#schema_block span.desc_type {
+.schema_block span.desc_type {
 	font-size:95%;
 	font-weight:700;
 }
 
-#schema_block img.schema_image {
+.schema_block img.schema_image {
 	float: right;
 	margin: 0 0 10px 10px
 }

--- a/schema-creator.php
+++ b/schema-creator.php
@@ -758,7 +758,7 @@ if ( !class_exists( "RavenSchema" ) ) :
 			}
 
 			// wrap schema build out
-			$sc_build = '<div id="schema_block" class="schema_'.$type.'">';
+			$sc_build = '<div class="schema_block schema_'.$type.'">';
 
 			// person
 			if(isset($type) && $type == 'person') {


### PR DESCRIPTION
This allows for multiple schema_block elements in a single page, without generating HTML errors. Schema.org respects the use of multiple Microdata items on a single page/post.

http://stackoverflow.com/questions/23611082/schema-org-setup-for-multiple-events-on-one-page